### PR TITLE
Fix PID prototype parsing and LEDC include

### DIFF
--- a/esps3drone/esps3drone.ino
+++ b/esps3drone/esps3drone.ino
@@ -27,6 +27,7 @@
 #include <WebServer.h>
 #include <Wire.h>
 #include <math.h>
+#include <esp32-hal-ledc.h>
 
 // ===== Altitude sensor selection (choose ONE) =====
 // #define USE_MS5611
@@ -75,6 +76,9 @@ int throttleDuty     = 0;                 // current throttle duty
 const int THROTTLE_SLEW_PER_TICK = 2;     // duty change limit per loop tick
 
 // ===== PID (outputs are duty deltas) =====
+struct PID;
+float pidStep(struct PID& p, float err, float dt);
+
 struct PID {
   float Kp, Ki, Kd;
   float iTerm=0, prevErr=0;
@@ -88,7 +92,8 @@ PID pitchPID{ 0.9f, 0.05f, 0.25f,0, 0, -25, 25, -15, 15 };  // gentle leveling
 
 static inline float fconstrain(float v, float a, float b) { return v<a?a:(v>b?b:v); }
 
-floa t pidStep(PID& p, float err, float dt) {
+// Execute one PID controller step
+float pidStep(struct PID& p, float err, float dt) {
   p.iTerm = fconstrain(p.iTerm + err * p.Ki * dt, p.iMin, p.iMax);
   const float d = (err - p.prevErr) / dt;
   p.prevErr = err;
@@ -97,6 +102,7 @@ floa t pidStep(PID& p, float err, float dt) {
 
 // ===== State machine =====
 enum FlightState { IDLE, TEST_MOTORS, TAKEOFF, HOVER, LANDING, DISARMED, ABORTED };
+void enterState(enum FlightState s);
 volatile FlightState fsm = IDLE;
 uint32_t stateStartMs = 0;
 
@@ -127,7 +133,7 @@ void motorSelfTest() {
   ledcWrite(M4_CH, t); delay(ms); ledcWrite(M4_CH, 0);
 }
 
-void enterState(FlightState s) { fsm = s; stateStartMs = millis(); }
+void enterState(enum FlightState s) { fsm = s; stateStartMs = millis(); }
 
 String stateName() {
   switch (fsm) {
@@ -163,7 +169,8 @@ bool initAlt() {
                   Adafruit_BMP280::SAMPLING_X8,
                   Adafruit_BMP280::SAMPLING_X8,
                   Adafruit_BMP280::FILTER_X16,
-                  Adafruit_BMP280::STANDBY_MS_20);
+                  // Use the closest available standby interval
+                  Adafruit_BMP280::STANDBY_MS_1);
   return true;
 #endif
 }


### PR DESCRIPTION
## Summary
- Work around Arduino's auto-prototype issues by forward-declaring PID and flight state helpers
- Include the ESP32 LEDC header so `ledcSetup` and friends resolve during compilation

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 esps3drone` *(fails: command not found)*
- `apt-get update` *(fails: 403 from proxy but completes)*
- `apt-get install -y arduino-cli` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68973c057b4083249e9aba78211cca0e